### PR TITLE
Small typo correction in ELASTIC_SEARCH/layout.html

### DIFF
--- a/app/views/ELASTIC_SEARCH/layout.html
+++ b/app/views/ELASTIC_SEARCH/layout.html
@@ -14,7 +14,7 @@
 		
 		#{if request.actionMethod != 'index'}
 			<div id="elasticsearchBreadcrumb">
-				#{elasticsearch.navigation /}
+				#{elasticSearch.navigation /}
 			</div>
 		#{/if}
 


### PR DESCRIPTION
There was a typo in the file that caused a render error.
