### PR TITLE
Make index event JPA independent

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,11 +3,11 @@
 <project name="elasticsearch" default="build" basedir=".">
 
 	<path id="project.classpath">
-		<pathelement path="/Users/felipera/play/framework/classes" />
-		<fileset dir="/Users/felipera/play/framework/lib">
+		<pathelement path="${play.path}/framework/classes" />
+		<fileset dir="${play.path}/framework/lib">
 			<include name="*.jar" />
 		</fileset>
-		<fileset dir="/Users/felipera/play/framework">
+		<fileset dir="${play.path}/framework">
 			<include name="*.jar" />
 		</fileset>
 		<fileset dir="lib">
@@ -18,15 +18,11 @@
 	<target name="compile">
 
 		<property environment="env" />
-		<property name="play.path" location="/Users/felipera/play" />
-		<condition property="env.PLAY_HOME" value="${env.HOME}/play">
-			<not>
-				<isset property="env.PLAY_HOME" />
-			</not>
-		</condition>
+		<property name="play.path" location="${play.path}/play" />
 		<property name="ant.build.javac.source" value="1.6" />
 		<property name="ant.build.javac.target" value="1.6" />
 
+		<mkdir dir="lib" />
 		<mkdir dir="tmp/classes" />
 		<javac srcdir="src" destdir="tmp/classes" target="1.6" debug="true"
 			classpathref="project.classpath">

--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -227,6 +227,10 @@ public class ElasticSearchPlugin extends PlayPlugin {
 		// Log Debug
 		Logger.info("Event: %s - Object: %s", message, context);
 
+		if (!message.endsWith(".objectPersisted") || !message.endsWith(".objectUpdated") || !message.endsWith(".objectDeleted")) {
+			return;
+		}
+
 		// Check if object has annotation
 		boolean isSearchable = this.isElasticSearchable(context);
 		// Logger.info("Searchable: %s", isSearchable);

--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -227,11 +227,6 @@ public class ElasticSearchPlugin extends PlayPlugin {
 		// Log Debug
 		Logger.info("Event: %s - Object: %s", message, context);
 
-		// Just accept JPA events
-		if (!StringUtils.startsWith(message, "JPASupport.")) {
-			return;
-		}
-
 		// Check if object has annotation
 		boolean isSearchable = this.isElasticSearchable(context);
 		// Logger.info("Searchable: %s", isSearchable);
@@ -269,11 +264,11 @@ public class ElasticSearchPlugin extends PlayPlugin {
 
 		// Define Event
 		ElasticSearchIndexEvent event = null;
-		if (message.equals("JPASupport.objectPersisted") || message.equals("JPASupport.objectUpdated")) {
+		if (message.endsWith(".objectPersisted") || message.endsWith(".objectUpdated")) {
 			// Index Model
 			event = new ElasticSearchIndexEvent((Model) context, ElasticSearchIndexEvent.Type.INDEX);
 
-		} else if (message.equals("JPASupport.objectDeleted")) {
+		} else if (message.endsWith(".objectDeleted")) {
 			// Delete Model from Index
 			event = new ElasticSearchIndexEvent((Model) context, ElasticSearchIndexEvent.Type.DELETE);
 		}


### PR DESCRIPTION
Hey Felipe,

As I would like to use the plugin with mongodb it must be JPA independent. This is pretty easy, due to not only listening on events beginning with "JPASupport" but checking its ending.

Small change, big impact, as I can change the morphia module then :-)

--Alexander
