### PR TITLE
Added support for entity hydration

### DIFF
--- a/src/play/modules/elasticsearch/ElasticSearch.java
+++ b/src/play/modules/elasticsearch/ElasticSearch.java
@@ -67,6 +67,22 @@ public abstract class ElasticSearch {
 		SearchRequestBuilder builder = client().prepareSearch(index).setSearchType(SearchType.QUERY_THEN_FETCH).setQuery(queryBuilder);
 		return builder;
 	}
+	
+	/**
+	 * Build a Query
+	 * 
+	 * @param <T>
+	 *            the generic type
+	 * @param queryBuilder
+	 *            the query builder
+	 * @param clazz
+	 *            the clazz
+	 * 
+	 * @return the query
+	 */
+	public static <T extends Model> Query query(XContentQueryBuilder queryBuilder, Class<T> clazz) {
+		return new Query(clazz, builder(queryBuilder, clazz));
+	}
 
 	/**
 	 * Search with optional facets.

--- a/src/play/modules/elasticsearch/ElasticSearch.java
+++ b/src/play/modules/elasticsearch/ElasticSearch.java
@@ -30,6 +30,7 @@ import org.elasticsearch.client.action.search.SearchRequestBuilder;
 import org.elasticsearch.index.query.xcontent.XContentQueryBuilder;
 import org.elasticsearch.search.facet.AbstractFacetBuilder;
 
+import play.Logger;
 import play.Play;
 import play.db.Model;
 
@@ -124,6 +125,16 @@ public abstract class ElasticSearch {
 		for( AbstractFacetBuilder facet : facets ) {
 			builder.addFacet(facet);
 		}
+		
+		// Only load id field for hydrate
+		if( hydrate ) {
+			builder.addField("_id");
+		}
+		
+		if( Logger.isDebugEnabled() ) {
+			Logger.debug("ES Query: %s", builder.toString());
+		}
+		
 		SearchResponse searchResponse = builder.execute().actionGet();
 		SearchResults searchResults = null;
 		if( hydrate ) {

--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -186,7 +186,7 @@ public class ElasticSearchPlugin extends PlayPlugin {
 		}
 
 		// Bind Admin
-		Router.addRoute("GET", "/es-admin/", "ElasticSearchAdmin.index");
+		Router.addRoute("GET", "/es-admin/", "elasticsearch.ElasticSearchAdmin.index");
 
 		// Check Client
 		if (client == null) {

--- a/src/play/modules/elasticsearch/Query.java
+++ b/src/play/modules/elasticsearch/Query.java
@@ -1,0 +1,83 @@
+package play.modules.elasticsearch;
+
+import org.apache.commons.lang.Validate;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.action.search.SearchRequestBuilder;
+import org.elasticsearch.search.facet.AbstractFacetBuilder;
+
+import play.Logger;
+import play.db.Model;
+import play.modules.elasticsearch.search.SearchResults;
+import play.modules.elasticsearch.transformer.JPATransformer;
+import play.modules.elasticsearch.transformer.Transformer;
+
+public class Query<T extends Model> {
+
+	private final Class<T> clazz;
+	private final SearchRequestBuilder builder;
+
+	private int from = -1;
+	private int size = -1;
+
+	private boolean hydrate = false;
+
+	Query(Class<T> clazz, SearchRequestBuilder builder) {
+		Validate.notNull(clazz, "clazz cannot be null");
+		Validate.notNull(builder, "builder cannot be null");
+		this.clazz = clazz;
+		this.builder = builder;
+	}
+
+	public Query from(int from) {
+		this.from = from;
+
+		return this;
+	}
+
+	public Query size(int size) {
+		this.size = size;
+
+		return this;
+	}
+
+	public Query hydrate(boolean hydrate) {
+		this.hydrate = hydrate;
+
+		return this;
+	}
+
+	public Query addFacet(AbstractFacetBuilder facet) {
+		Validate.notNull(facet, "facet cannot be null");
+		builder.addFacet(facet);
+
+		return this;
+	}
+
+	public SearchResults<T> fetch() {
+		// Paging
+		if (from > -1) {
+			builder.setFrom(from);
+		}
+		if (size > -1) {
+			builder.setSize(size);
+		}
+
+		// Only load id field for hydrate
+		if (hydrate) {
+			builder.addField("_id");
+		}
+
+		if (Logger.isDebugEnabled()) {
+			Logger.debug("ES Query: %s", builder.toString());
+		}
+
+		SearchResponse searchResponse = builder.execute().actionGet();
+		SearchResults searchResults = null;
+		if (hydrate) {
+			searchResults = JPATransformer.toSearchResults(searchResponse, clazz);
+		} else {
+			searchResults = Transformer.toSearchResults(searchResponse, clazz);
+		}
+		return searchResults;
+	}
+}

--- a/src/play/modules/elasticsearch/transformer/JPATransformer.java
+++ b/src/play/modules/elasticsearch/transformer/JPATransformer.java
@@ -61,6 +61,11 @@ public class JPATransformer {
 			// Fetch JPA entities from database while preserving ES result order
 			objects = loadFromDb(clazz, ids);
 			sortByIds(objects, ids);
+			
+			// Make sure all items exist in the database
+			if( objects.size() != ids.size() ) {
+				throw new IllegalStateException("Please re-index, not all indexed items are available in the database");
+			}
 		} else {
 			objects = Collections.emptyList();
 		}

--- a/src/play/modules/elasticsearch/transformer/JPATransformer.java
+++ b/src/play/modules/elasticsearch/transformer/JPATransformer.java
@@ -1,0 +1,115 @@
+package play.modules.elasticsearch.transformer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+
+import play.Logger;
+import play.data.binding.Binder;
+import play.db.Model;
+import play.db.jpa.JPQL;
+import play.exceptions.UnexpectedException;
+import play.modules.elasticsearch.search.SearchResults;
+
+/**
+ * Transforms ES SearchResponse to a list of hydrated entities
+ * 
+ * @author Bas
+ *
+ */
+public class JPATransformer {
+	
+	/**
+	 * To search results.
+	 * 
+	 * @param <T>
+	 *            the generic type
+	 * @param searchResponse
+	 *            the search response
+	 * @param clazz
+	 *            the clazz
+	 * @return the search results
+	 */
+	public static <T extends Model> SearchResults<T> toSearchResults(
+			SearchResponse searchResponse, Class<T> clazz) {
+		// Get Total Records Found
+		long count = searchResponse.hits().totalHits();
+
+		// Get key information
+		Model.Factory factory = Model.Manager.factoryFor(clazz);
+		Class<?> keyType = factory.keyType();
+		String keyName = factory.keyName();
+
+		// Loop on each one
+		List<Object> ids = new ArrayList<Object>();
+		for (SearchHit h : searchResponse.hits()) {
+			// Get Data Map
+			Map<String, Object> map = h.getSource();
+			Logger.debug("Record Map: %s", map);
+			
+			try {
+				ids.add(Binder.directBind(map.get(keyName).toString(), keyType));
+	        } catch (Exception e) {
+	            throw new UnexpectedException("Could not convert the ID from index to corresponding type", e);
+	        }
+		}
+		
+		Logger.info("Model IDs returned by ES: %s", ids);
+
+		List<T> objects = null;
+		
+		if( ids.size() > 0 ) {
+			// Fetch JPA entities from database while preserving ES result order
+			objects = loadFromDb(clazz, ids);
+			sortByIds(objects, ids);
+		} else {
+			objects = Collections.emptyList();
+		}
+		
+		Logger.info("Models after sorting: %s", objects);
+
+		// Return Results
+		return new SearchResults(count, objects, searchResponse.facets());
+	}
+
+	/**
+	 * Load entities from database
+	 * 
+	 * @param <T>
+	 * @param clazz
+	 * @param ids
+	 * @return
+	 */
+	private static <T extends Model> List<T> loadFromDb(Class<T> clazz, List<Object> ids) {
+		// JPA maps the "id" field to the key automatically
+		List<T> objects = JPQL.instance.find(clazz.getName(), "id in (?1)",
+				new Object[] { ids }).fetch();
+
+		return objects;
+	}
+
+	/**
+	 * Sort list of objects according to the order of their keys as defined by ids
+	 * 
+	 * @param <T>
+	 * @param objects
+	 * @param ids
+	 */
+	private static <T extends Model> void sortByIds(List<T> objects, final List<Object> ids) {
+		Collections.sort(objects, new Comparator<T>() {
+
+			@Override
+			public int compare(T arg0, T arg1) {
+				Integer idx1 = ids.indexOf(arg0._key());
+				Integer idx2 = ids.indexOf(arg1._key());
+
+				return idx1.compareTo(idx2);
+			}
+		});
+	}
+}

--- a/src/play/modules/elasticsearch/transformer/JPATransformer.java
+++ b/src/play/modules/elasticsearch/transformer/JPATransformer.java
@@ -59,7 +59,7 @@ public class JPATransformer {
 	        }
 		}
 		
-		Logger.info("Model IDs returned by ES: %s", ids);
+		Logger.debug("Model IDs returned by ES: %s", ids);
 
 		List<T> objects = null;
 		
@@ -71,7 +71,7 @@ public class JPATransformer {
 			objects = Collections.emptyList();
 		}
 		
-		Logger.info("Models after sorting: %s", objects);
+		Logger.debug("Models after sorting: %s", objects);
 
 		// Return Results
 		return new SearchResults(count, objects, searchResponse.facets());

--- a/src/play/modules/elasticsearch/transformer/JPATransformer.java
+++ b/src/play/modules/elasticsearch/transformer/JPATransformer.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;
@@ -43,17 +42,12 @@ public class JPATransformer {
 		// Get key information
 		Model.Factory factory = Model.Manager.factoryFor(clazz);
 		Class<?> keyType = factory.keyType();
-		String keyName = factory.keyName();
 
 		// Loop on each one
 		List<Object> ids = new ArrayList<Object>();
 		for (SearchHit h : searchResponse.hits()) {
-			// Get Data Map
-			Map<String, Object> map = h.getSource();
-			Logger.debug("Record Map: %s", map);
-			
 			try {
-				ids.add(Binder.directBind(map.get(keyName).toString(), keyType));
+				ids.add(Binder.directBind(h.getId(), keyType));
 	        } catch (Exception e) {
 	            throw new UnexpectedException("Could not convert the ID from index to corresponding type", e);
 	        }


### PR DESCRIPTION
Hi,

I've added basic support for hydrating JPA entities.
To prevent n+1 the code performs a batch-load for all search results at once; Next, if sorts the hydrated entities to match the search result order.

This new functionality is available through ElasticSearch.searchAndHydrate() so it doesn't break existing code.

Bas
