### PR TITLE
Documentation updated

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -52,21 +52,20 @@ h2. Enable the module
 
 After installing the module, add the following to your conf/dependencies.yml to enable it (don't forget to run play dependencies):
 
-bc. - play -> elasticsearch 0.0.9
-
+bc. require:
+	- play -> elasticsearch 0.0.9
 
 
 h2. Configure the module
 
 You need to configure the module by setting these properties in your application.conf. There are two ways to run your Play! app with Elastic Search, local mode or client mode. Local mode works well for development purposes, an Elastic Search instance will run on the same JVM as your Play! application automatically. You won't need to setup another service, etc. The second option is client mode which fits better in a production environment. The default option is local mode.
 
-bc.. # Option 1) Elastic Search (Local Model)
+bc. # Option 1) Elastic Search (Local Model)
 elasticsearch.local=true
 
-# Option 2) Elastic Search (Client Model)
+bc. # Option 2) Elastic Search (Client Model)
 elasticsearch.local=false
 elasticsearch.client=mynode1:9200,mynode2:9200
-
 
 
 h2. Usage
@@ -79,8 +78,7 @@ bc.. @ElasticSearchable
 @Entity
 public class Post extends Model {
  
-    public String title;   
-
+    public String title;
     public Date postedAt;
     
 }
@@ -95,8 +93,7 @@ Basically you need to create a controller class and extend ElasticSearchControll
 bc.. @ElasticSearchController.For(ElasticSearchSampleModel.class)
 public class ElasticSearchExample extends ElasticSearchController {
 
-} 
-			
+}
 
 p. You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
 

--- a/README.textile
+++ b/README.textile
@@ -44,15 +44,15 @@ h2. Install the module
 
 Install the elasticsearch module from the modules repository:
 
-@play install elasticsearch@
+bc. play install elasticsearch
 
 
 
 h2. Enable the module
 
-After installing the module, add the following to your application.conf to enable it:
+After installing the module, add the following to your conf/dependencies.yml to enable it (don't forget to run play dependencies):
 
-@module.elasticsearch=${play.path}/modules/elasticsearch-0.0.6@
+bc. - play -> elasticsearch 0.0.9
 
 
 
@@ -60,12 +60,12 @@ h2. Configure the module
 
 You need to configure the module by setting these properties in your application.conf. There are two ways to run your Play! app with Elastic Search, local mode or client mode. Local mode works well for development purposes, an Elastic Search instance will run on the same JVM as your Play! application automatically. You won't need to setup another service, etc. The second option is client mode which fits better in a production environment. The default option is local mode.
 
-				@# Option 1) Elastic Search (Local Model)
-				elasticsearch.local=true@
+bc.. # Option 1) Elastic Search (Local Model)
+elasticsearch.local=true
 
-				@# Option 2) Elastic Search (Client Model)
-				elasticsearch.local=false
-				elasticsearch.client=mynode1:9200,mynode2:9200@
+# Option 2) Elastic Search (Client Model)
+elasticsearch.local=false
+elasticsearch.client=mynode1:9200,mynode2:9200
 
 
 
@@ -75,16 +75,15 @@ You basically need to add annotation "@ElasticSearchable" to your Model class. I
 
 Example:
 
-				@ElasticSearchable
-				@Entity
-				public class Post extends Model {
-				 
-				    public String title;
-				    
-				
-				    public Date postedAt;
-				    
-				}
+bc.. @ElasticSearchable
+@Entity
+public class Post extends Model {
+ 
+    public String title;   
+
+    public Date postedAt;
+    
+}
 
 
 
@@ -93,13 +92,13 @@ h2. Searching
 The biggest change on this release is a nicer search interface. We are providing a very simple way to get started, inspired by Play!'s CRUD module.
 Basically you need to create a controller class and extend ElasticSearchController. Use annotation @ElasticSearchController.For(YOURMODELCLASS.class) to tell our module what model you want to search on, here's an example:
 
-				@ElasticSearchController.For(ElasticSearchSampleModel.class)
-				public class ElasticSearchExample extends ElasticSearchController {
-				
-				} 
+bc.. @ElasticSearchController.For(ElasticSearchSampleModel.class)
+public class ElasticSearchExample extends ElasticSearchController {
+
+} 
 			
 
-You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
+p. You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
 
 
 

--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -96,6 +96,8 @@ class Education {
 
 h2. Searching
 
+h3. ElasticSearchController
+
 The biggest change on this release is a nicer search interface. We are providing a very simple way to get started, inspired by Play!'s CRUD module.
 Basically you need to create a controller class and extend ElasticSearchController. Use annotation @ElasticSearchController.For(YOURMODELCLASS.class) to tell our module what model you want to search on, here's an example:
 
@@ -105,6 +107,24 @@ public class ElasticSearchExample extends ElasticSearchController {
 }
 
 p. You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
+
+h3. Custom search
+
+After you've created your XContentQueryBuilder object, you can search in two ways:
+
+1) Call ElasticSearch.search()
+2) Call ElasticSearch.query() and subsequently set query parameters (e.g. paging)
+
+If you are searching for JPA entities and need referenced entities to be available (e.g. @ManyToOne or @OneToMany relationships), use 
+
+bc. ElasticSearch.searchAndHydrate(...)
+
+or call hydrate(true) on your Query:
+
+bc. Query query = ElasticSearch.query(...);
+query.hydrate(true)
+
+This will take care of hydrating your entities so proxies and collections work.
 
 
 h2. User Interface 

--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -1,4 +1,3 @@
-
 h1. Play Framework - Elastic Search Module
 
 by Felipe Oliveira [@_felipera]
@@ -25,51 +24,75 @@ The main advantages are:
 Integrate Elastic Search in a Play! Framework Application. This module uses JPA events to notify Elastic Search of events of their own. In Local Mode it embeds a running Elastic Search instance (port 9200 by default), a good choice for development. In Client Mode it connects to an external instance of Elastic Search, that might be your setup in production.
 
 
-
 h2. Prerequisites
 
 Play! 1.2
-
 
 
 h2. Enable the module
 
 After installing the module, add the following to your conf/dependencies.yml to enable it (don't forget to run play dependencies):
 
-- play -> elasticsearch 0.0.7
-
+bc. - play -> elasticsearch 0.0.9
 
 
 h2. Configure the module
 
 You need to configure the module by setting these properties in your application.conf. There are two ways to run your Play! app with Elastic Search, local mode or client mode. Local mode works well for development purposes, an Elastic Search instance will run on the same JVM as your Play! application automatically. You won't need to setup another service, etc. The second option is client mode which fits better in a production environment. The default option is local mode.
 
-				@# Option 1) Elastic Search (Local Model)
-				elasticsearch.local=true@
+bc.. # Option 1) Elastic Search (Local Model)
+elasticsearch.local=true
 
-				@# Option 2) Elastic Search (Client Model)
-				elasticsearch.local=false
-				elasticsearch.client=mynode1:9200,mynode2:9200@
-
+# Option 2) Elastic Search (Client Model)
+elasticsearch.local=false
+elasticsearch.client=mynode1:9200,mynode2:9200
 
 
 h2. Usage
+
+h3. @ElasticSearchable
 
 You basically need to add annotation "@ElasticSearchable" to your Model class. It only works for JPA so far. If a model has that annotation our module we'll watching for JPA events for instances of that class and route messages to Elastic Search to make sure Elastic Search index has the latest information available on the database.
 
 Example:
 
-				@ElasticSearchable
-				@Entity
-				public class Post extends Model {
-				 
-				    public String title;
-				    
-				
-				    public Date postedAt;
-				    
-				}
+bc.. @ElasticSearchable
+@Entity
+public class Post extends Model {
+ 
+    public String title;    
 
+    public Date postedAt;
+    
+}
+
+p. It's possible to prevent fields from being included in the index by marking them with @ElasticSearchIgnore.
+
+h3. @ElasticSearchEmbedded
+
+p. Since 0.0.9 it's possible to embed properties by using "@ElasticSearchEmbedded".
+
+bc.. class Institution {
+	public String name;
+	public String type;
+}
+
+@ElasticSearchable
+class Education {
+	...
+	@ElasticSearchEmbedded
+	Institution institution;
+}
+	
+p. This will add institution.id and institution.name to education.
+By default all fields are embedded, which can be overriden by specifying the fields to embed:
+
+bc.. @ElasticSearchable
+class Education {
+	...
+	@ElasticSearchEmbedded(fields={"name"})
+	Institution institution;
+}
 
 
 h2. Searching
@@ -77,14 +100,13 @@ h2. Searching
 The biggest change on this release is a nicer search interface. We are providing a very simple way to get started, inspired by Play!'s CRUD module.
 Basically you need to create a controller class and extend ElasticSearchController. Use annotation @ElasticSearchController.For(YOURMODELCLASS.class) to tell our module what model you want to search on, here's an example:
 
-				@ElasticSearchController.For(ElasticSearchSampleModel.class)
-				public class ElasticSearchExample extends ElasticSearchController {
-				
-				} 
+bc.. @ElasticSearchController.For(ElasticSearchSampleModel.class)
+public class ElasticSearchExample extends ElasticSearchController {
+
+}
 			
 
-You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
-
+p. You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
 
 
 h2. User Interface 
@@ -92,13 +114,9 @@ h2. User Interface
 After you start your application (play run), you should have an admin interface automatically running on http://localhost:9000/es-admin/.
 
 
-
-
 h2. Source Code
 
 Fork it on Github (https://github.com/feliperazeek/playframework-elasticsearch).
-
-
 
 
 h2. Roadmap
@@ -109,8 +127,21 @@ h2. Roadmap
 * Customizations for mapping, etc
 
 
-
 h2. Credits
 
 * Shay Banon for the great work with Elastic Search and Compass, I have been following his work for a few years, great stuff.
 * Ben Birch (https://github.com/mobz) for the work on the User Interface.
+
+
+h2. Changelog
+
+h3. Version 0.0.9:
+
+* Embedded property support through @ElasticSearchEmbedded
+* Fixed a bug which prevented model create- and update-events from being processed
+* ElasticSearchController now uses elastic search for searching
+
+h3. Version 0.0.8:
+
+* JPA entity hydration support
+* Query support

--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -33,17 +33,18 @@ h2. Enable the module
 
 After installing the module, add the following to your conf/dependencies.yml to enable it (don't forget to run play dependencies):
 
-bc. - play -> elasticsearch 0.0.9
+bc. require:
+	- play -> elasticsearch 0.0.9
 
 
 h2. Configure the module
 
 You need to configure the module by setting these properties in your application.conf. There are two ways to run your Play! app with Elastic Search, local mode or client mode. Local mode works well for development purposes, an Elastic Search instance will run on the same JVM as your Play! application automatically. You won't need to setup another service, etc. The second option is client mode which fits better in a production environment. The default option is local mode.
 
-bc.. # Option 1) Elastic Search (Local Model)
+bc. # Option 1) Elastic Search (Local Model)
 elasticsearch.local=true
 
-# Option 2) Elastic Search (Client Model)
+bc. # Option 2) Elastic Search (Client Model)
 elasticsearch.local=false
 elasticsearch.client=mynode1:9200,mynode2:9200
 
@@ -60,8 +61,7 @@ bc.. @ElasticSearchable
 @Entity
 public class Post extends Model {
  
-    public String title;    
-
+    public String title;
     public Date postedAt;
     
 }
@@ -72,12 +72,12 @@ h3. @ElasticSearchEmbedded
 
 p. Since 0.0.9 it's possible to embed properties by using "@ElasticSearchEmbedded".
 
-bc.. class Institution {
+bc. class Institution {
 	public String name;
 	public String type;
 }
 
-@ElasticSearchable
+bc. @ElasticSearchable
 class Education {
 	...
 	@ElasticSearchEmbedded
@@ -87,13 +87,12 @@ class Education {
 p. This will add institution.id and institution.name to education.
 By default all fields are embedded, which can be overriden by specifying the fields to embed:
 
-bc.. @ElasticSearchable
+bc. @ElasticSearchable
 class Education {
 	...
 	@ElasticSearchEmbedded(fields={"name"})
 	Institution institution;
 }
-
 
 h2. Searching
 
@@ -104,7 +103,6 @@ bc.. @ElasticSearchController.For(ElasticSearchSampleModel.class)
 public class ElasticSearchExample extends ElasticSearchController {
 
 }
-			
 
 p. You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
 


### PR DESCRIPTION
I've updated the documentation to reflect my recent changes.

I also think I may have figured out why the documentation isn't showing up on playframework.org: There is a newline before the initial h1.
Up to 0.0.3 (http://www.playframework.org/modules/elasticsearch-0.0.3/home) the documentation was working, from 0.0.4 it stopped working.

Let's find out if the documentation works again...

Sebastian
