### PR TITLE
Upgraded module to ES 0.19.3

### DIFF
--- a/app/controllers/elasticsearch/ElasticSearchController.java
+++ b/app/controllers/elasticsearch/ElasticSearchController.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.elasticsearch.common.base.Strings;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 
@@ -317,8 +316,8 @@ public class ElasticSearchController extends Controller {
 		 */
 		private BoolQueryBuilder buildQueryBuilder(String search, String searchFields, String where) {
 			BoolQueryBuilder qb = boolQuery();
-			
-			if( Strings.isNullOrEmpty(search)) {
+
+			if(search == null || search.isEmpty()) {
 				qb.must(QueryBuilders.matchAllQuery());
 			} else {
 				// FIXME Currently we search in all fields and ignore searchFields

--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -5,7 +5,7 @@ self: play -> elasticsearch 0.5
 require:
     - play
     - play -> crud
-    - org.elasticsearch -> elasticsearch 0.18.5
+    - org.elasticsearch -> elasticsearch 0.19.3
     - se.scalablesolutions.akka -> akka-amqp 1.1.2
     
     
@@ -18,6 +18,6 @@ repositories:
             
     - akka:
         type: iBiblio
-        root: "http://akka.io/repository/"
+        root: "http://repo.typesafe.com/typesafe/akka-releases-cache/"
         contains:
             - se.scalablesolutions.akka -> *

--- a/src/play/modules/elasticsearch/ElasticSearch.java
+++ b/src/play/modules/elasticsearch/ElasticSearch.java
@@ -18,9 +18,9 @@
  */
 package play.modules.elasticsearch;
 
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.action.search.SearchRequestBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.facet.AbstractFacetBuilder;
 

--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -169,6 +169,8 @@ public class ElasticSearchPlugin extends PlayPlugin {
 					throw new RuntimeException("Invalid Host: " + host);
 				}
 				Logger.info("Transport Client - Host: %s Port: %s", parts[0], parts[1]);
+				if(Integer.valueOf(parts[1]) == 9200)
+					Logger.info("Note: Port 9200 is usually used by the HTTP Transport. You might want to use 9300 instead.");
 				c.addTransportAddress(new InetSocketTransportAddress(parts[0], Integer.valueOf(parts[1])));
 				done = true;
 			}

--- a/src/play/modules/elasticsearch/Query.java
+++ b/src/play/modules/elasticsearch/Query.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.Validate;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.action.search.SearchRequestBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.facet.AbstractFacetBuilder;
 import org.elasticsearch.search.sort.SortBuilder;


### PR DESCRIPTION
I've upgraded the module to use ElasticSearch 0.19.3
For this I had to
- update conf/depdencies.yml
- fix some imports

I also added a notice when using remote nodes that warns if a user specifies port 9200 in elasticsearch.client
as this port is used for communication over http, while the InetSocketTransportAddress does not rely on HTTP, so configuring 9200 instead of 9300 will lead to hard to debug errors.
