### PR TITLE
2 new features

### DIFF
--- a/src/play/modules/elasticsearch/mapping/impl/DefaultMapperFactory.java
+++ b/src/play/modules/elasticsearch/mapping/impl/DefaultMapperFactory.java
@@ -28,6 +28,10 @@ public class DefaultMapperFactory implements MapperFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public <M> ModelMapper<M> getMapper(Class<M> clazz) throws MappingException {
+		if (clazz.equals(play.db.Model.class)) {
+			return (ModelMapper<M>) new UniversalModelMapper();
+		}
+		
 		if (!MappingUtil.isSearchable(clazz)) {
 			throw new MappingException("Class must be annotated with @ElasticSearchable");
 		}

--- a/src/play/modules/elasticsearch/mapping/impl/UniversalModelMapper.java
+++ b/src/play/modules/elasticsearch/mapping/impl/UniversalModelMapper.java
@@ -1,0 +1,54 @@
+package play.modules.elasticsearch.mapping.impl;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import play.db.Model;
+import play.modules.elasticsearch.mapping.ModelMapper;
+
+/**
+ * Mapper implmementation used for retrieval from multiple indices
+ * 
+ * @author filip.stefanak@gmail.com
+ * 
+ */
+public class UniversalModelMapper implements ModelMapper<Model> {
+
+	@Override
+	public Class<Model> getModelClass() {
+		return Model.class;
+	}
+
+	@Override
+	public String getIndexName() {
+		return "_all";
+	}
+
+	@Override
+	public String getTypeName() {
+		return "_all";
+	}
+
+	@Override
+	public String getDocumentId(final Model model) {
+		return "_all";
+	}
+
+	@Override
+	public void addMapping(final XContentBuilder builder) throws IOException {
+		throw new UnsupportedOperationException("Unsupported call to UniversalModelMapper");
+	}
+
+	@Override
+	public void addModel(final Model model, final XContentBuilder builder) throws IOException {
+		throw new UnsupportedOperationException("Unsupported call to UniversalModelMapper");
+	}
+
+	@Override
+	public Model createModel(final Map<String, Object> map) {
+		throw new UnsupportedOperationException("Model mapping is not supported with UniversalModelMapper");
+	}
+
+}

--- a/src/play/modules/elasticsearch/transformer/MapperTransformer.java
+++ b/src/play/modules/elasticsearch/transformer/MapperTransformer.java
@@ -66,10 +66,16 @@ public class MapperTransformer<T extends Model> implements Transformer<T> {
         List<Float> scores = new ArrayList<Float>();
         List<Object[]> sortValues = new ArrayList<Object[]>();
 
-        ModelMapper<T> mapper = ElasticSearchPlugin.getMapper(clazz);
+        Class<T> hitClazz = clazz;
+        ModelMapper<T> mapper = ElasticSearchPlugin.getMapper(hitClazz);
 
 		// Loop on each one
 		for (SearchHit h : searchResponse.hits()) {
+			if (clazz.equals(play.db.Model.class)) {
+				 hitClazz = (Class<T>) ElasticSearchPlugin.lookupModel(h.getType());
+				 mapper = ElasticSearchPlugin.getMapper(hitClazz);
+			}
+			
 			// Get Data Map
 			Map<String, Object> map = h.sourceAsMap();
 			Logger.debug("Record Map: %s", map);

--- a/src/play/modules/elasticsearch/transformer/SimpleTransformer.java
+++ b/src/play/modules/elasticsearch/transformer/SimpleTransformer.java
@@ -27,6 +27,7 @@ import org.elasticsearch.search.SearchHit;
 
 import play.Logger;
 import play.db.Model;
+import play.modules.elasticsearch.ElasticSearchPlugin;
 import play.modules.elasticsearch.search.SearchResults;
 import play.modules.elasticsearch.util.ReflectionUtil;
 
@@ -63,10 +64,16 @@ public class SimpleTransformer<T extends Model> implements Transformer<T> {
         List<Object[]> sortValues = new ArrayList<Object[]>();
 
         // Loop on each one
+        Class<T> hitClazz = clazz;
 		for (SearchHit h : searchResponse.hits()) {
 			// Init Model Class
 			Logger.debug("Starting Record!");
-			T o = ReflectionUtil.newInstance(clazz);
+			if (clazz.equals(Model.class)) {
+				hitClazz = (Class<T>) ElasticSearchPlugin.lookupModel(h.getType());
+			}
+			T o = ReflectionUtil.newInstance(hitClazz);
+			 
+			
 
 			// Get Data Map
 			Map<String, Object> map = h.sourceAsMap();


### PR DESCRIPTION
1) ElasticSearchPlugin can be blocked so it does not process events but
instead stores them to a queue. The queue can be later processed
synchronously with a single invocation. This can be used to work around
issue #35.
2) Search now supports queries over all models (indices). Just pass
class play.db.Model as a search argument clazz.
