### PR TITLE
Allow for custom IndexEventHandlers

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -61,7 +61,7 @@ h2. Enable the module
 After installing the module, add the following to your conf/dependencies.yml to enable it (don't forget to run play dependencies):
 
 bc. require:
-	- play -> elasticsearch 0.2
+	- play -> elasticsearch 0.5
 
 
 h2. Configure the module
@@ -111,6 +111,33 @@ public class ElasticSearchExample extends ElasticSearchController {
 }
 
 p. You should be able to search on http://localhost:9000/elasticSearchExample/index. If you want to customize the views, just create a directory ELASTIC_SEARCH under views and change whatever you need to change.
+
+
+h2. Indexing
+The ElasticSearch Plugin features some strategies to configure the way your models are indexed.
+These strategies implement the Interface play.modules.elasticsearch.IndexEventHandler. There are two built-in IndexEventHandler implementations and since 0.5 a way to add your own:
+
+h3. play.modules.elasticsearch.LocalIndexEventHandler
+
+This IndexEventHandler uses a EventStream introduces in Play 1.2. to handle index events.
+As the EventStream is limited to about 100 messages and then overflows, this is only a good candidate if you're not importing lots of documents at a time.
+The LocalIndexEventHandler is used by default or when setting
+elasticsearch.delivery = LOCAL
+in your application.conf
+
+h3. play.modules.elasticsearch.rabbitmq.RabbitMQIndexEventHandler
+A IndexEventHandler using Akka and RabbitMQ for handling IndexEvents. 
+Use it by setting 
+elasticsearch.delivery = RABBITMQ
+in your application.conf
+
+h3. Your own IndexEventHandler (new in 0.5)
+Since 0.5 you can specify your own IndexEventHandler without modifying the Plugin. To do this, create a class implementing play.modules.elasticsearch.IndexEventHandler
+somewhere in your Play Project, e.g. in a package called handlers and specify the following in your application.conf
+elasticsearch.delivery = CUSTOM
+elasticsearch.customIndexEventHandler = helpers.MyCustomIndexEventHandler
+
+Make sure your custom IndexEventHandler implements the interface mentioned above and does have a default no-args constructor. 
 
 
 

--- a/README.textile
+++ b/README.textile
@@ -114,6 +114,8 @@ p. You should be able to search on http://localhost:9000/elasticSearchExample/in
 
 
 h2. Indexing
+
+
 The ElasticSearch Plugin features some strategies to configure the way your models are indexed.
 These strategies implement the Interface play.modules.elasticsearch.IndexEventHandler. There are two built-in IndexEventHandler implementations and since 0.5 a way to add your own:
 

--- a/README.textile
+++ b/README.textile
@@ -124,20 +124,29 @@ h3. play.modules.elasticsearch.LocalIndexEventHandler
 This IndexEventHandler uses a EventStream introduces in Play 1.2. to handle index events.
 As the EventStream is limited to about 100 messages and then overflows, this is only a good candidate if you're not importing lots of documents at a time.
 The LocalIndexEventHandler is used by default or when setting
-elasticsearch.delivery = LOCAL
+
+bc. elasticsearch.delivery = LOCAL
+
 in your application.conf
 
+
 h3. play.modules.elasticsearch.rabbitmq.RabbitMQIndexEventHandler
+
 A IndexEventHandler using Akka and RabbitMQ for handling IndexEvents. 
 Use it by setting 
-elasticsearch.delivery = RABBITMQ
+
+bc. elasticsearch.delivery = RABBITMQ
+
 in your application.conf
 
 h3. Your own IndexEventHandler (new in 0.5)
+
 Since 0.5 you can specify your own IndexEventHandler without modifying the Plugin. To do this, create a class implementing play.modules.elasticsearch.IndexEventHandler
 somewhere in your Play Project, e.g. in a package called handlers and specify the following in your application.conf
-elasticsearch.delivery = CUSTOM
+
+bc. elasticsearch.delivery = CUSTOM
 elasticsearch.customIndexEventHandler = helpers.MyCustomIndexEventHandler
+
 
 Make sure your custom IndexEventHandler implements the interface mentioned above and does have a default no-args constructor. 
 

--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -142,6 +142,8 @@ public class ElasticSearchPlugin extends PlayPlugin {
 		if (s == null) {
 			return ElasticSearchDeliveryMode.LOCAL;
 		}
+        if("CUSTOM".equals(s))
+            return ElasticSearchDeliveryMode.createCustomIndexEventHandler(Play.configuration.getProperty("elasticsearch.customIndexEventHandler", "play.modules.elasticsearch.LocalIndexEventHandler"));
 		return ElasticSearchDeliveryMode.valueOf(s.toUpperCase());
 	}
 


### PR DESCRIPTION
Attached Pull request allows users to create their own IndexEventHandlers without altering the Plugin code. 

For this I had to change the enum ElasticSearchDeliveryMode to a class. 
I also added new configuration options and described them in the README as well as in the source code. 

Please merge the pull request and release a new version 0.5. 
Thanks a lot for your good work.

Dominik
