### PR TITLE
multifield type support

### DIFF
--- a/src/play/modules/elasticsearch/annotations/ElasticSearchFieldDescriptor.java
+++ b/src/play/modules/elasticsearch/annotations/ElasticSearchFieldDescriptor.java
@@ -1,0 +1,44 @@
+package play.modules.elasticsearch.annotations;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.List;
+
+import org.elasticsearch.common.collect.Lists;
+
+public class ElasticSearchFieldDescriptor {
+
+	private List<ElasticSearchField> annotations = Lists.newArrayList();
+
+	public ElasticSearchFieldDescriptor(Field field) {
+		if (field.getAnnotation(ElasticSearchField.class) != null) {
+			this.annotations = Lists.newArrayList(field.getAnnotation(ElasticSearchField.class));
+		} else if (field.getAnnotation(ElasticSearchMultiField.class) != null) {
+			this.annotations = Lists.newArrayList(field.getAnnotation(ElasticSearchMultiField.class).value());
+		}
+	}
+
+	public String type() {
+		return annotations.get(0).type();
+	}
+
+	public Collection<ElasticSearchField> getFields() {
+		return annotations;
+	}
+
+	public boolean hasType() {
+		return hasField() && getField().type().length() > 0;
+	}
+
+	public ElasticSearchField getField() {
+		return annotations.get(0);
+	}
+
+	public boolean isMultiField() {
+		return annotations.size() > 1;
+	}
+
+	public boolean hasField() {
+		return annotations.isEmpty() == false;
+	}
+}

--- a/src/play/modules/elasticsearch/annotations/ElasticSearchMultiField.java
+++ b/src/play/modules/elasticsearch/annotations/ElasticSearchMultiField.java
@@ -1,0 +1,14 @@
+package play.modules.elasticsearch.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ElasticSearchMultiField {
+
+	ElasticSearchField[] value();
+
+}

--- a/src/play/modules/elasticsearch/mapping/impl/AbstractFieldMapper.java
+++ b/src/play/modules/elasticsearch/mapping/impl/AbstractFieldMapper.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Field;
 
 import org.apache.commons.lang.Validate;
 
-import play.modules.elasticsearch.annotations.ElasticSearchField;
+import play.modules.elasticsearch.annotations.ElasticSearchFieldDescriptor;
 import play.modules.elasticsearch.mapping.FieldMapper;
 import play.modules.elasticsearch.mapping.MappingUtil;
 import play.modules.elasticsearch.util.ReflectionUtil;
@@ -18,13 +18,13 @@ import play.modules.elasticsearch.util.ReflectionUtil;
 public abstract class AbstractFieldMapper<M> implements FieldMapper<M> {
 
 	protected final Field field;
-	protected final ElasticSearchField meta;
+	protected final ElasticSearchFieldDescriptor meta;
 	private final String prefix, indexField;
 
-	public AbstractFieldMapper(Field field, String prefix) {
+	public AbstractFieldMapper(final Field field, String prefix) {
 		Validate.notNull(field, "field cannot be null");
 		this.field = field;
-		this.meta = field.getAnnotation(ElasticSearchField.class);
+		this.meta = new ElasticSearchFieldDescriptor(field);
 		this.prefix = prefix;
 
 		// Maybe this a premature optimization, but getIndexField() will be
@@ -88,7 +88,7 @@ public abstract class AbstractFieldMapper<M> implements FieldMapper<M> {
 	 * @return
 	 */
 	protected String getIndexType() {
-		if (meta != null && meta.type().length() > 0) {
+		if (meta.hasType()) {
 			// Type was explicitly set, use it
 			return meta.type();
 

--- a/test/mapping/MultiFieldTest.java
+++ b/test/mapping/MultiFieldTest.java
@@ -1,0 +1,71 @@
+package mapping;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.junit.Test;
+
+import play.db.jpa.Model;
+import play.modules.elasticsearch.annotations.ElasticSearchField;
+import play.modules.elasticsearch.annotations.ElasticSearchField.Index;
+import play.modules.elasticsearch.annotations.ElasticSearchField.Store;
+import play.modules.elasticsearch.annotations.ElasticSearchMultiField;
+import play.modules.elasticsearch.annotations.ElasticSearchable;
+import play.modules.elasticsearch.mapping.ModelMapper;
+
+public class MultiFieldTest extends MappingTest {
+
+	@SuppressWarnings("serial")
+	@ElasticSearchable
+	public static class TestModel extends Model {
+		@ElasticSearchMultiField({
+				@ElasticSearchField(index = Index.not_analyzed, store = Store.yes, type = "string"),
+				@ElasticSearchField(index = Index.analyzed, store = Store.no, type = "string")
+		})
+		public String name;
+	}
+
+	@Test
+	public void testFieldProperties() throws IOException {
+		ModelMapper<TestModel> mapper = getMapper(TestModel.class);
+		assertNotNull(mapper);
+
+		// Get generated mapping
+		XContentBuilder generatedMapping = mappingFor(mapper);
+
+		// Build mapping locally for verification
+		XContentBuilder mapping = builder();
+		mapping.startObject();
+		mapping.startObject(mapper.getTypeName());
+		mapping.startObject("properties");
+
+		// Order matters, see AbstractFieldMapper
+		mapping.startObject("name");
+		mapping.field("type", "multi_field");
+		mapping.startObject("fields");
+		mapping.startObject("untouched");
+		mapping.field("type", "string");
+		mapping.field("index", "not_analyzed");
+		mapping.field("store", "yes");
+		mapping.endObject();
+		mapping.startObject("name");
+		mapping.field("type", "string");
+		mapping.field("index", "analyzed");
+		mapping.field("store", "no");
+		mapping.endObject();
+		mapping.endObject();
+		mapping.endObject();
+
+		// Play model id
+		mapping.startObject("id");
+		mapping.field("type", "long");
+		mapping.endObject();
+
+		mapping.endObject();
+		mapping.endObject();
+		mapping.endObject();
+
+		assertEquals(mapping.string(), generatedMapping.string());
+	}
+
+}


### PR DESCRIPTION
To sort by fields that have multiple words there need to be two fields defined in index.
This elastic search feature is explained here : http://www.elasticsearch.org/guide/reference/mapping/multi-field-type.html

This is a simple solution to handle that
