### PR TITLE
Support TTL

### DIFF
--- a/src/play/modules/elasticsearch/annotations/ElasticSearchTtl.java
+++ b/src/play/modules/elasticsearch/annotations/ElasticSearchTtl.java
@@ -1,0 +1,19 @@
+package play.modules.elasticsearch.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * class with this interface with have a _ttl field in elastic search index:
+ * http://www.elasticsearch.org/guide/reference/mapping/ttl-field.html
+ * 
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ElasticSearchTtl {
+
+	String value();
+
+}

--- a/test/mapping/TtlTest.java
+++ b/test/mapping/TtlTest.java
@@ -1,0 +1,53 @@
+package mapping;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.junit.Test;
+
+import play.modules.elasticsearch.annotations.ElasticSearchTtl;
+import play.modules.elasticsearch.annotations.ElasticSearchable;
+import play.modules.elasticsearch.mapping.ModelMapper;
+
+public class TtlTest extends MappingTest {
+
+	@SuppressWarnings("serial")
+	@ElasticSearchable
+	@ElasticSearchTtl("10s")
+	public static class ObjectToMap {
+
+		public String name;
+
+	}
+
+	@Test
+	public void testFieldProperties() throws IOException {
+		ModelMapper<ObjectToMap> mapper = getMapper(ObjectToMap.class);
+		assertNotNull(mapper);
+
+		// Get generated mapping
+		XContentBuilder generatedMapping = mappingFor(mapper);
+
+		// Build mapping locally for verification
+		XContentBuilder mapping = builder();
+		mapping.startObject();
+		mapping.startObject(mapper.getTypeName());
+		mapping.startObject("_ttl");
+		mapping.field("enabled", true);
+		mapping.field("default", "10s");
+		mapping.endObject();
+		mapping.startObject("properties");
+
+		// Order matters, see AbstractFieldMapper
+		mapping.startObject("name");
+		mapping.field("type", "string");
+		mapping.endObject();
+
+		mapping.endObject();
+
+		mapping.endObject();
+
+		assertEquals(mapping.string(), generatedMapping.string());
+	}
+
+}


### PR DESCRIPTION
Module can support TTL Field for a Document with an annotation:

@ElasticSearchTtl("1d")
@ElasticSearchable
