### PR TITLE
Lookup models without indexing them first

### DIFF
--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -22,6 +22,7 @@ import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +42,7 @@ import play.PlayPlugin;
 import play.db.Model;
 import play.modules.elasticsearch.ElasticSearchIndexEvent.Type;
 import play.modules.elasticsearch.adapter.ElasticSearchAdapter;
+import play.modules.elasticsearch.annotations.ElasticSearchable;
 import play.modules.elasticsearch.mapping.MapperFactory;
 import play.modules.elasticsearch.mapping.MappingUtil;
 import play.modules.elasticsearch.mapping.ModelMapper;
@@ -332,7 +334,17 @@ public class ElasticSearchPlugin extends PlayPlugin {
 	 * @return Class of the Model
 	 */
 	public static Class<?> lookupModel(final String indexType) {
-		return modelLookup.get(indexType);
+		final Class<?> clazz = modelLookup.get(indexType);
+		if (clazz != null) { // we have not cached this model yet
+			return clazz;
+		}
+		final List<Class> searchableModels = Play.classloader.getAnnotatedClasses(ElasticSearchable.class);
+		for (final Class searchableModel : searchableModels) {
+			if (getMapper(searchableModel).getTypeName() == indexType) {
+				return searchableModel;
+			}
+		}
+		throw new IllegalArgumentException("Type name '" + indexType + "' is not searchable!");
 	}
 
 }

--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -44,6 +44,7 @@ import play.modules.elasticsearch.ElasticSearchIndexEvent.Type;
 import play.modules.elasticsearch.adapter.ElasticSearchAdapter;
 import play.modules.elasticsearch.annotations.ElasticSearchable;
 import play.modules.elasticsearch.mapping.MapperFactory;
+import play.modules.elasticsearch.mapping.MappingException;
 import play.modules.elasticsearch.mapping.MappingUtil;
 import play.modules.elasticsearch.mapping.ModelMapper;
 import play.modules.elasticsearch.mapping.impl.DefaultMapperFactory;
@@ -340,8 +341,12 @@ public class ElasticSearchPlugin extends PlayPlugin {
 		}
 		final List<Class> searchableModels = Play.classloader.getAnnotatedClasses(ElasticSearchable.class);
 		for (final Class searchableModel : searchableModels) {
-			if (indexType.equals(getMapper(searchableModel).getTypeName())) {
-				return searchableModel;
+			try {
+				if (indexType.equals(getMapper(searchableModel).getTypeName())) {
+					return searchableModel;
+				}
+			} catch (final MappingException ex) {
+				// mapper can not be retrieved
 			}
 		}
 		throw new IllegalArgumentException("Type name '" + indexType + "' is not searchable!");

--- a/src/play/modules/elasticsearch/ElasticSearchPlugin.java
+++ b/src/play/modules/elasticsearch/ElasticSearchPlugin.java
@@ -340,7 +340,7 @@ public class ElasticSearchPlugin extends PlayPlugin {
 		}
 		final List<Class> searchableModels = Play.classloader.getAnnotatedClasses(ElasticSearchable.class);
 		for (final Class searchableModel : searchableModels) {
-			if (getMapper(searchableModel).getTypeName() == indexType) {
+			if (indexType.equals(getMapper(searchableModel).getTypeName())) {
 				return searchableModel;
 			}
 		}


### PR DESCRIPTION
JPATransformer had an issue: when using generalized hydrated search over multiple indices, class resolution would fail if the class was not cached by the plugin. This happens when you start Play with an index that is already filled and tried to search on it without indexing (Indexing populates the cache).

The fix: when the cache does not contain class for the given index name, we iterate over all searchable models and determine the one which resolves to the same name.
