### PR TITLE
Updated "Class must be annotated with @ElasticSearchable" exception

### DIFF
--- a/src/play/modules/elasticsearch/mapping/impl/DefaultMapperFactory.java
+++ b/src/play/modules/elasticsearch/mapping/impl/DefaultMapperFactory.java
@@ -33,7 +33,7 @@ public class DefaultMapperFactory implements MapperFactory {
 		}
 		
 		if (!MappingUtil.isSearchable(clazz)) {
-			throw new MappingException("Class must be annotated with @ElasticSearchable");
+			throw new MappingException("Class \"" + clazz.getCanonicalName() + "\" must be annotated with @ElasticSearchable");
 		}
 
 		if (play.db.Model.class.isAssignableFrom(clazz)) {


### PR DESCRIPTION
Updated the error message to include the canonical name of the class which caused it.

e.g. "Class "models.Product" must be annotated with @ElasticSearchable"
