### PR TITLE
remove elasticsearch repository

### DIFF
--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -10,12 +10,6 @@ require:
     
     
 repositories:
-    - elasticsearch:
-        type: iBiblio
-        root: "http://oss.sonatype.org/content/repositories/releases/"
-        contains:
-            - org.elasticsearch -> *
-            
     - akka:
         type: iBiblio
         root: "http://repo.typesafe.com/typesafe/akka-releases-cache/"


### PR DESCRIPTION
When running `play dependencies`, play cannot resolve the elasticsearch files, but with the default repositories, the can be found.
